### PR TITLE
Upgrade ArgoCD to v 1.5.x

### DIFF
--- a/helm/saasty/Chart.yaml
+++ b/helm/saasty/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: v2
 name: saasty-preview
 description: Agile Toolkit Demo App Chart
 type: application

--- a/projects/agiletoolkit.org/kube/argo.tf
+++ b/projects/agiletoolkit.org/kube/argo.tf
@@ -15,7 +15,7 @@ data "helm_repository" "argocd" {
 
 resource "helm_release" "argocd" {
   chart = "argo-cd"
-  version    = "1.5.2"
+  version = "1.5.2"
   name = "argo"
   namespace = "argocd"
   repository = data.helm_repository.argocd.url

--- a/projects/agiletoolkit.org/kube/argo.tf
+++ b/projects/agiletoolkit.org/kube/argo.tf
@@ -15,6 +15,7 @@ data "helm_repository" "argocd" {
 
 resource "helm_release" "argocd" {
   chart = "argo-cd"
+  version    = "1.5.2"
   name = "argo"
   namespace = "argocd"
   repository = data.helm_repository.argocd.url


### PR DESCRIPTION
https://blog.argoproj.io/argo-cd-v1-5-generally-available-a16b9a2347ba

 - local accounts - should allow us to better manage access to argocd
 - helm3 / helm schema v2